### PR TITLE
Initialize npm setup with Three.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "prometheus-webgl",
       "version": "1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "three": "^0.164.0"
+        "three": "^0.164.1"
       },
       "devDependencies": {
-        "vite": "^5.0.0"
+        "vite": "^5.4.19"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,19 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "start": "vite",
+    "build": "vite build"
   },
   "dependencies": {
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
-  }
+    "vite": "^5.4.19"
+  },
+  "description": "Ein futuristisches Strategiespiel im Stil von *Deuteros*, *Millennium 2.2* und *Supremacy* – vollständig im Webbrowser spielbar per **WebGL**, mit **Grafiken**, **Sound**, und optional **Touch/Controller-Support**.",
+  "main": "index.js",
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
 }


### PR DESCRIPTION
## Summary
- run `npm init -y` and install Three.js
- add start and build scripts for Vite

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895e2b0f280832390cd2a6207b91229