### PR TITLE
Add MIT license and contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Prometheus
+
+We welcome contributions of all kinds. To keep the project healthy and easy to work with, please follow these guidelines.
+
+## Getting Started
+- Fork the repository and create your branch from `main`.
+- Run `npm install` to install dependencies.
+- Use `npm run dev` for local development.
+
+## Code Style
+- Use modern JavaScript (ES6+) and keep the code modular.
+- Follow existing patterns in the `src/` directory when adding new modules.
+- Run formatting tools if available and keep the code lint-free.
+
+## Submitting Changes
+1. Ensure the project builds with `npm run build`.
+2. Commit your changes with clear, descriptive messages.
+3. Open a Pull Request explaining the motivation and context of your change.
+
+## Reporting Issues
+- Use the GitHub issue tracker to report bugs or request features.
+- Provide as much detail as possible, including steps to reproduce the issue.
+- Check for existing issues before opening a new one.
+
+Thank you for helping to improve Prometheus!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Prometheus contributors 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Die gebauten Dateien werden im Verzeichnis `dist/` abgelegt und können von jede
 
 ## Beitragende / Contributions
 
-Beiträge sind willkommen! Ein ausführlicher Leitfaden folgt. Bis dahin gerne Issues oder Pull Requests eröffnen.
+Beiträge sind willkommen! Hinweise zum Beitrag findest du in [CONTRIBUTING.md](CONTRIBUTING.md). Lizenzinformationen stehen in der [LICENSE](LICENSE).
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and the [LICENSE](LICENSE) for licensing.
 
 ## Hinweis an Codex
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
   "main": "index.js",
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- document contribution workflow in `CONTRIBUTING.md`
- reference license and guidelines from `README` and package metadata

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e48560488323b2e1bf2a91e648af