### PR TITLE
Fix hddtest load address and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 ## Description
 
 This is a simple x86 32 bit operating system written "from scratch" with many help from other sources.
+
+## Usage
+
+To load and execute the test program, run `hddtest` in the shell and then
+start it with `run 0x100000`.

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -595,9 +595,9 @@ int writehdd(int s, int c) {
 #define GIGABYTE 1073741824
 
 void hddtest() {
-    for(unsigned int i=0; i<2880; i++) {
-        read_from_disk(i, (void*)0x100000+(512*i), 512);
-    }
+    // Lade test.pc, das ab Sektor 2048 (1 MiB) liegt, nach 0x100000
+    read_from_disk(2048, (void*)0x100000, 951);
+    printf("test.pc geladen. Starte mit 'run 0x100000'\n");
 }
 
 void hddtest2() {


### PR DESCRIPTION
## Summary
- Load `test.pc` from sector 2048 directly to memory at 0x100000.
- Clarify in documentation to run the test program via `run 0x100000`.

## Testing
- `make os-image.bin`
- `make run` *(fails: Makefile:60: run, Error 127)*

------
https://chatgpt.com/codex/tasks/task_e_689a766f4838832394c7ae01d054f8c4