### PR TITLE
Fix interrupt handler and update BGA demo

### DIFF
--- a/cpu/isr.c
+++ b/cpu/isr.c
@@ -123,8 +123,10 @@ void isr_handler(registers_t *r) {
     print_string(exception_messages[r->int_no]);
     print_nl();
 
-    isr_t handler = interrupt_handlers[IRQ10];
-    handler(r);
+    if (interrupt_handlers[r->int_no]) {
+        isr_t handler = interrupt_handlers[r->int_no];
+        handler(r);
+    }
 }
 
 void register_interrupt_handler(uint8_t n, isr_t handler) {

--- a/programs/bga_demo.c
+++ b/programs/bga_demo.c
@@ -1,5 +1,6 @@
 #include "../drivers/ports.h"
 #include "../drivers/display.h"
+#include "../drivers/video.h"
 #include "../kernel/util.h"
 
 #define BGA_INDEX_PORT 0x1CE
@@ -14,6 +15,8 @@
 #define BGA_LFB_ENABLED    0x40
 
 int bga_demo() {
+    init_video();
+
     uint16_t width = 800;
     uint16_t height = 600;
     uint16_t bpp = 32;
@@ -40,7 +43,7 @@ int bga_demo() {
     port_word_out(BGA_INDEX_PORT, BGA_REG_ENABLE);
     port_word_out(BGA_DATA_PORT, BGA_ENABLED | BGA_LFB_ENABLED);
 
-    uint32_t *lfb = (uint32_t *)0xE0000000;
+    volatile uint32_t *lfb = (volatile uint32_t *)0xE0000000;
     for (uint32_t y = 0; y < height; y++) {
         for (uint32_t x = 0; x < width; x++) {
             uint8_t r = (x * 255) / width;
@@ -57,9 +60,6 @@ int txt() {
     /* Disable BGA and return to VGA text mode */
     port_word_out(BGA_INDEX_PORT, BGA_REG_ENABLE);
     port_word_out(BGA_DATA_PORT, 0);
-
-    /* BIOS call to set 80x25 text mode */
-    asm volatile("mov $0x0003, %%ax; int $0x10" ::: "ax");
 
     clear_screen();
     return 0;


### PR DESCRIPTION
## Summary
- Properly dispatch interrupts only to registered handlers
- Initialize video and use volatile frame buffer in BGA demo
- Remove BIOS text-mode interrupt to avoid crash in protected mode

## Testing
- `make` *(fails: QEMU fehlt (install qemu-system-x86))*
- `make os-image.bin`


------
https://chatgpt.com/codex/tasks/task_e_689a993188c88323871e933000725d09