### PR TITLE
Reset VGA flip-flop before palette writes

### DIFF
--- a/programs/bga_demo.c
+++ b/programs/bga_demo.c
@@ -72,11 +72,15 @@ static void write_registers(unsigned char *regs) {
 
     /* AC */
     for (i = 0; i < 21; i++) {
+        /* Reset flip-flop before each attribute controller access */
+        port_byte_in(0x3DA);
         port_byte_out(0x3C0, i);
+        port_byte_in(0x3DA);
         port_byte_out(0x3C0, *regs++);
     }
 
     /* Lock palette and unblank */
+    port_byte_in(0x3DA);
     port_byte_out(0x3C0, 0x20);
 }
 


### PR DESCRIPTION
## Summary
- reset the VGA attribute controller flip-flop by reading port 0x3DA before each write to port 0x3C0

## Testing
- `make kernel.bin`


------
https://chatgpt.com/codex/tasks/task_e_689aa1750b6c83238bc62dfd81c11efc