### PR TITLE
Add paging helper for BGA framebuffer

### DIFF
--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -111,6 +111,9 @@ void start_kernel() {
 
         init_memory();
 
+        init_paging();
+        map_framebuffer(0xE0000000, 0xE0000000, 4 * 1024 * 1024);
+
      //   print_string("A20 Line was activated by the MBR.\n");
         // enable_a20_line();
 

--- a/kernel/mem.h
+++ b/kernel/mem.h
@@ -16,3 +16,9 @@ void print_dynamic_mem();
 void *mem_alloc(size_t size);
 
 void mem_free(void *p);
+
+void init_paging();
+
+void *map_framebuffer(uint32_t phys, uint32_t virt, size_t size);
+
+extern volatile uint32_t *framebuffer;

--- a/programs/bga_demo.c
+++ b/programs/bga_demo.c
@@ -2,6 +2,7 @@
 #include "../drivers/display.h"
 #include "../drivers/video.h"
 #include "../kernel/util.h"
+#include "../kernel/mem.h"
 
 void showcursor();
 
@@ -115,7 +116,7 @@ int bga_demo() {
     port_word_out(BGA_INDEX_PORT, BGA_REG_ENABLE);
     port_word_out(BGA_DATA_PORT, BGA_ENABLED | BGA_LFB_ENABLED);
 
-    volatile uint32_t *lfb = (volatile uint32_t *)0xE0000000;
+    volatile uint32_t *lfb = framebuffer;
     for (uint32_t y = 0; y < height; y++) {
         for (uint32_t x = 0; x < width; x++) {
             uint8_t r = (x * 255) / width;


### PR DESCRIPTION
## Summary
- implement basic paging setup and a helper to map the framebuffer
- initialize paging early and map the BGA framebuffer
- use the mapped framebuffer in `bga_demo` instead of a hardcoded address

## Testing
- `make kernel.bin`


------
https://chatgpt.com/codex/tasks/task_e_689b339ac35c8323b6bf0b857198f9b2