### PR TITLE
Reset palette and console state after BGA demo

### DIFF
--- a/drivers/display.c
+++ b/drivers/display.c
@@ -36,7 +36,10 @@ int setpal() {
         port_byte_out(0x03C9, i * 16); // Blauwert (graduell anpassen)
     }
 
-    // Deine Farben sind jetzt gesetzt!
+    // Reset console defaults after changing the palette
+    g_ConsoleColor = WHITE_ON_BLACK;
+    g_ConsoleX = 0;
+    g_ConsoleY = 0;
 
     return 0;
 }

--- a/drivers/display.h
+++ b/drivers/display.h
@@ -86,3 +86,6 @@ void hexdump(void *ptr, size_t size);
 void printHexByte(unsigned char c);
 
 void print_registers();
+
+int setpal();
+int get_offset(int col, int row);

--- a/programs/bga_demo.c
+++ b/programs/bga_demo.c
@@ -137,9 +137,15 @@ int txt() {
     /* Reprogram VGA registers back to text mode */
     write_registers(text_mode_80x25);
 
+    /* Reload default palette and console state */
+    setpal();
+
+    /* Clear the screen and reposition the cursor */
     clear_screen();
+    set_cursor(get_offset(0, 0));
     showcursor();
-    printf("%c ", 0x10);
+
+    printf("Text mode restored\n");
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Reset console color and position inside `setpal`
- Use `setpal()` in `txt()` to restore palette and cursor
- Clear text mode screen and print a verification string

## Testing
- `make kernel.bin`

------
https://chatgpt.com/codex/tasks/task_e_689b3583d5d083239fe5e8e50001c734