### PR TITLE
Add ESC wait loop to BGA demo

### DIFF
--- a/programs/bga_demo.c
+++ b/programs/bga_demo.c
@@ -4,8 +4,10 @@
 #include "../kernel/util.h"
 #include "../kernel/mem.h"
 #include "../drivers/font8x16.h"
+#include "../drivers/keyboard.h"
 
 void showcursor();
+int txt();
 
 #define BGA_INDEX_PORT 0x1CE
 #define BGA_DATA_PORT  0x1CF
@@ -126,7 +128,10 @@ int bga_demo() {
             lfb[y * width + x] = (r << 16) | (g << 8) | b;
         }
     }
-
+    while (getkey() != SC_ESC) {
+        // wait for ESC key
+    }
+    txt();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- wait for ESC key in BGA graphics demo
- restore text mode via `txt()` after exiting

## Testing
- `make programs/bga_demo.o`

------
https://chatgpt.com/codex/tasks/task_e_689b3b315700832398e87a2d988c7308