### PR TITLE
Handle missing framebuffer mapping in BGA demo

### DIFF
--- a/programs/bga_demo.c
+++ b/programs/bga_demo.c
@@ -118,6 +118,12 @@ int bga_demo() {
     port_word_out(BGA_INDEX_PORT, BGA_REG_ENABLE);
     port_word_out(BGA_DATA_PORT, BGA_ENABLED | BGA_LFB_ENABLED);
 
+    if (framebuffer == NULL_POINTER) {
+        if (map_framebuffer(0xE0000000, 0xE0000000, width * height * (bpp / 8)) == NULL_POINTER) {
+            printf("Framebuffer mapping failed\n");
+            return -1;
+        }
+    }
     volatile uint32_t *lfb = framebuffer;
     for (uint32_t y = 0; y < height; y++) {
         for (uint32_t x = 0; x < width; x++) {


### PR DESCRIPTION
## Summary
- Map the BGA framebuffer on demand if it's not already available
- Emit an error and abort when framebuffer mapping fails

## Testing
- `make kernel.bin`

------
https://chatgpt.com/codex/tasks/task_e_689b3fe303848323b9595f1b95f5261d